### PR TITLE
Do not treat literal as a doctest

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,9 @@
 //! This module defines structs for serde based
 //! deserialization of the configuration
 //!
-//! The hierarchy is
+//! The hierarchy is:
 //!
-//! ```
-//!  Config > Account > Certificate
-//! ```
+//! `Config > Account > Certificate`
 use serde::Deserialize;
 use std::{net::SocketAddr, path::PathBuf};
 


### PR DESCRIPTION
Currently `cargo test` fails due to treating `Config > Account > Certificate` as a [doctest](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html).

Even though there are no unit tests, this will help later on, as well as prevent failure in any automated systems that might run `cargo test`.