### PR TITLE
Build static binaries on the CI for easier install

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Prepare
+        run: >
+          sudo apt-get install -y musl musl-tools
       - name: Checkout
         uses: actions/checkout@v1
 
@@ -28,23 +31,24 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          target: x86_64-unknown-linux-musl
           default: true
           override: true
 
       - name: Build
         run: >
-             cargo build --locked --bins --release &&
-             strip target/release/agnos &&
-             strip target/release/agnos-generate-accounts-keys &&
-             mv target/release/agnos target/release/agnos_amd64 &&
-             mv target/release/agnos-generate-accounts-keys target/release/agnos-generate-accounts-keys_amd64
+             cargo build --locked --bins --release --target=x86_64-unknown-linux-musl --features openssl/vendored &&
+             strip target/x86_64-unknown-linux-musl/release/agnos &&
+             strip target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys &&
+             mv target/x86_64-unknown-linux-musl/release/agnos target/x86_64-unknown-linux-musl/release/agnos_amd64 &&
+             mv target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys_amd64
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            target/release/agnos_amd64
-            target/release/agnos-generate-accounts-keys_amd64
+            target/x86_64-unknown-linux-musl/release/agnos_amd64
+            target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys_amd64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ These instructions are given for a Linux system but a similar process will likel
 
 ## Released binary
 
-Pre-compiled binaries for (relatively recent) Linux/amd64 are available for every tagged [release](https://github.com/krtab/agnos/releases). They are known to not work on Debian 11.
+Pre-compiled binaries for Linux/amd64 are available for every tagged [release](https://github.com/krtab/agnos/releases). Be aware that they are statically built using musl and vendoring their own openssl so that they can easily be installed even on older distributions.
 
 ## Archlinux AUR package
 


### PR DESCRIPTION
Closes: https://github.com/krtab/agnos/issues/37
Closes: https://github.com/krtab/agnos/issues/31