### PR TITLE
Rename: dns_listen_adr -> dns_listen_addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ There are three "levels" in the configuration:
 The general configuration level is where the IP address to listen on is provided.
 
 ```toml
-dns_listen_adr = "1.2.3.4:53"
+dns_listen_addr = "1.2.3.4:53"
 ```
 
 ### 2. Accounts

--- a/config_example.toml
+++ b/config_example.toml
@@ -1,6 +1,6 @@
 # Address for the DNS server to listen on.
 # The port should probably be 53.
-dns_listen_adr = "1.2.3.4:53"
+dns_listen_addr = "1.2.3.4:53"
 
 # A first account
 # accounts are identified by

--- a/src/bin/agnos.rs
+++ b/src/bin/agnos.rs
@@ -104,7 +104,7 @@ async fn main() -> anyhow::Result<()> {
         tokio::fs::read_to_string(cli_ops.get_one::<String>("config").unwrap()).await?;
     let config: Config = toml::from_str(&config_file)?;
 
-    let dns_worker = DnsWorker::new(config.dns_listen_adr).await?;
+    let dns_worker = DnsWorker::new(config.dns_listen_addr).await?;
     let dns_handle = dns_worker.challenges();
 
     let acme_url = if cli_ops.get_flag("no-staging") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,9 @@ use std::{net::SocketAddr, path::PathBuf};
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// One listening address per config
-    pub dns_listen_adr: SocketAddr,
+    // Legacy misspelled alias. TODO: remove in a future version
+    #[serde(alias = "dns_listen_adr")]
+    pub dns_listen_addr: SocketAddr,
     /// Several accounts per config
     pub accounts: Vec<Account>,
 }

--- a/test-docker/agnos/config_test.toml
+++ b/test-docker/agnos/config_test.toml
@@ -1,6 +1,6 @@
 # Address for the DNS server to listen on.
 # The port should probably be 53.
-dns_listen_adr = "0.0.0.0:53"
+dns_listen_addr = "0.0.0.0:53"
 
 # A first account
 # accounts are identified by


### PR DESCRIPTION
Fixes https://github.com/krtab/agnos/issues/34 . The legacy alias is supported for now to keep compatibility.