### PR TITLE
Update Dockerfile to use ghcr.io-hosted pebble images

### DIFF
--- a/test-docker/pebble/Dockerfile
+++ b/test-docker/pebble/Dockerfile
@@ -1,4 +1,4 @@
-FROM letsencrypt/pebble:latest
+FROM ghcr.io/letsencrypt/pebble:latest
 
 ENV PEBBLE_VA_NOSLEEP=1
 


### PR DESCRIPTION
We have deprecated and plan to remove the dockerhub-hosted versions in the future.

I found this Dockerfile with github search and have not tested your project with this change at all.