### PR TITLE
configurable renewal time

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@ In the configuration file, `accounts.certificates` is a TOML [array of tables](h
 domains =  ["doma.in","*.doma.in"]
 fullchain_output_file = "fullchain_A.pem"
 key_output_file = "cert_key_A.pem"
+renewal_days_advance = 30 # Renew certificate 30 days in advance of its expiration (this is the default value and can be omitted).
 
 # A second certificate ordered for that account.
 [[accounts.certificates]]
+renewal_days_advance = 21 # Renew certificate 21 days in advance of its expiration.
 domains =  ["examp.le","another.examp.le","and.a.completely.different.one"]
 fullchain_output_file = "fullchain_B.pem"
 key_output_file = "cert_key_B.pem"
@@ -226,7 +228,7 @@ _acme-challenge.another.examp.le    NS      agnos-ns.doma.in
 
 `agnos` takes a single command line argument, the path to its configuration file, and two optional flags: `--no-staging` to use Let's Encrypt production server, and `--debug` to display more debug information. Help is available via `agnos --help`.
 
-When running, it checks whether the certificates of the full chain are going to expire in the next 30 days, and only renew them in that case, so it is suitable to be used in a cron job.
+When running, it checks whether the certificates of the full chain are going to expire in the next 30 days (by default), and only renew them in that case, so it is suitable to be used in a cron job.
 
 ## Systemd units
 

--- a/config_example.toml
+++ b/config_example.toml
@@ -17,11 +17,13 @@ domains =  ["doma.in","*.doma.in"]
 fullchain_output_file = "fullchain_A.pem"
 key_output_file = "cert_key_A.pem"
 
-# A second certificate ordered for that account.
+# A second certificate ordered for that account,
 [[accounts.certificates]]
 domains =  ["examp.le","another.examp.le","and.a.completely.different.one"]
 fullchain_output_file = "fullchain_B.pem"
 key_output_file = "cert_key_B.pem"
+# Renew certificate 21 days in advance of its expiration (defaults to 30 if omitted).
+renewal_days_advance = 21 
 
 # A second account
 [[accounts]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,13 @@ pub struct Account {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Certificate {
+    #[serde(default = "default_days")]
+    pub renewal_days_advance: u32,
     pub domains: Vec<String>,
     pub fullchain_output_file: PathBuf,
     pub key_output_file: PathBuf,
+}
+
+const fn default_days() -> u32 {
+    30
 }

--- a/src/main_logic.rs
+++ b/src/main_logic.rs
@@ -131,7 +131,8 @@ pub async fn process_config_certificate(
             tracing::info!("Certificate chain found on disk, checking its validity");
             let current_certs = openssl::x509::X509::stack_from_pem(&f)?;
             let mut need_renewal = false;
-            let today_plus_validity = openssl::asn1::Asn1Time::days_from_now(30)?;
+            let days = config_cert.renewal_days_advance;
+            let today_plus_validity = openssl::asn1::Asn1Time::days_from_now(days)?;
             for c in current_certs {
                 let end = c.not_after();
                 let to_renew = end < today_plus_validity;
@@ -148,7 +149,8 @@ pub async fn process_config_certificate(
                 return Ok(());
             } else {
                 tracing::info!(
-                    "A certificate in the chain expires in 30 days or less, renewing it."
+                    "A certificate in the chain expires in {d} days or less, renewing it.",
+                    d = days
                 )
             }
         }


### PR DESCRIPTION
this allows certificates to be queued for renewal when within a custom amount of days, not just 30. I kept 30 as the default, so this shouldn't break any currently working configs!