### PR TITLE
 Add Docker build and improve release build

### DIFF
--- a/.github/workflows/rust_build.yml
+++ b/.github/workflows/rust_build.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Build
         run: >
              cargo build --locked --bins --release --target=x86_64-unknown-linux-musl --features openssl/vendored &&
-             strip target/x86_64-unknown-linux-musl/release/agnos &&
-             strip target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys &&
              mv target/x86_64-unknown-linux-musl/release/agnos target/x86_64-unknown-linux-musl/release/agnos_amd64 &&
              mv target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys_amd64
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,7 @@ version = "4.0.2"
 features = ["cargo"]
 
 [features]
+
+[profile.release]
+strip = true
+lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM --platform=$BUILDPLATFORM rust:1.85.1-alpine3.21 AS builder
+ENV PKGCONFIG_SYSROOTDIR=/
+RUN apk add --no-cache musl-dev libressl-dev perl build-base zig
+RUN cargo install --locked cargo-zigbuild
+RUN rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+WORKDIR /app
+COPY Cargo.toml Cargo.lock .
+RUN mkdir src \
+  && echo "fn main() {}" > src/main.rs \
+  && cargo fetch \
+  && cargo zigbuild --release --locked --features openssl/vendored --target x86_64-unknown-linux-musl --target aarch64-unknown-linux-musl \
+  && rm src/main.rs
+COPY src ./src
+RUN cargo zigbuild --release --bins --locked --features openssl/vendored --target x86_64-unknown-linux-musl --target aarch64-unknown-linux-musl
+
+FROM --platform=$BUILDPLATFORM scratch AS binary
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/agnos /agnos-linux-amd64
+COPY --from=builder /app/target/aarch64-unknown-linux-musl/release/agnos /agnos-linux-arm64
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys /agnos-generate-accounts-keys-linux-amd64
+COPY --from=builder /app/target/aarch64-unknown-linux-musl/release/agnos-generate-accounts-keys /agnos-generate-accounts-keys-linux-arm64
+
+FROM alpine:3.21.3 AS runner
+ARG TARGETOS
+ARG TARGETARCH
+COPY --from=binary /agnos-${TARGETOS}-${TARGETARCH} /usr/bin/agnos
+COPY --from=binary /agnos-generate-accounts-keys-${TARGETOS}-${TARGETARCH} /usr/bin/agnos-generate-accounts-keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM rust:1.85.1-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM rust:1.87.0-alpine3.22 AS builder
 ENV PKGCONFIG_SYSROOTDIR=/
 RUN apk add --no-cache musl-dev libressl-dev perl build-base zig
 RUN cargo install --locked cargo-zigbuild
@@ -19,7 +19,7 @@ COPY --from=builder /app/target/aarch64-unknown-linux-musl/release/agnos /agnos-
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/agnos-generate-accounts-keys /agnos-generate-accounts-keys-linux-amd64
 COPY --from=builder /app/target/aarch64-unknown-linux-musl/release/agnos-generate-accounts-keys /agnos-generate-accounts-keys-linux-arm64
 
-FROM alpine:3.21.3 AS runner
+FROM alpine:3.22.0 AS runner
 ARG TARGETOS
 ARG TARGETARCH
 COPY --from=binary /agnos-${TARGETOS}-${TARGETARCH} /usr/bin/agnos

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 build-release:
 	cargo build --locked --bins --release
-	strip target/release/agnos
-	strip target/release/agnos-generate-accounts-keys
 	ln target/release/agnos agnos
 	ln target/release/agnos-generate-accounts-keys agnos-generate-accounts-keys

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ or more explicitly:
 
 ```bash
 cargo build --locked --bins --release
-strip target/release/agnos
-strip target/release/agnos-generate-accounts-keys
 ln target/release/agnos agnos
 ln target/release/agnos-generate-accounts-keys agnos-generate-accounts-keys
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Agnos leverages let's encrypt capability to follow DNS `NS` records. It requires
     1. [Configuration of your DNS provider](#configuration-of-your-dns-provider)
     1. [Running agnos](#running-agnos)
     1. [Systemd units](#systemd-units)
+    1. [Docker Compose](#docker-compose)
 1. [Developers](#developers)
     1. [Integration testing](#integration-testing)
 1. [User feedback requested](#user-feedback-requested)
@@ -239,6 +240,10 @@ When running, it checks whether the certificates of the full chain are going to 
 ## Systemd units
 
 A systemd unit and timers are provided in the `systemd` folder of this repo.
+
+## Docker Compose
+
+An example Docker Compose configuration is provided at the root of this repo.
 
 # Developers
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,17 @@
+services:
+  agnos:
+    build: .
+    container_name: agnos
+    restart: unless-stopped
+    ports:
+      - "53:53/udp"
+    volumes:
+      - /etc/agnos:/etc/agnos:rw
+    command:
+      - sh
+      - -c
+      - >
+        agnos-generate-accounts-keys --key-size 4096 --no-confirm /etc/agnos/config.toml
+        && agnos --no-staging /etc/agnos/config.toml
+        && echo 'Retrying in one hour...'
+        && sleep 3600


### PR DESCRIPTION
Supersedes #76 and closes #79

- Move the [`strip` option into Cargo](https://doc.rust-lang.org/cargo/reference/profiles.html#strip) (so it's no longer necessary to manually call `strip` on the binaries)
- Add Link Time Optimization (LTO) to Cargo release options
- Add a Dockerfile that builds both Agnos binaries, cross-compiling to amd64 and arm64 (See: https://hub.docker.com/r/epiceric/agnos)
- Add a sample Docker Compose file